### PR TITLE
Add Shared preferences in the core module (Issue 56)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ android {
 
 dependencies {
     implementation (project(BuildModules.Libraries.Data))
+    implementation (project(BuildModules.Libraries.Core))
     implementation (project(BuildModules.Libraries.Network))
     implementation (project(BuildModules.Libraries.Repository))
 

--- a/core/src/main/java/com/android254/droidconKE2020/core/Preferences.kt
+++ b/core/src/main/java/com/android254/droidconKE2020/core/Preferences.kt
@@ -1,0 +1,4 @@
+package com.android254.droidconKE2020.core
+
+interface Preferences {
+}

--- a/core/src/main/java/com/android254/droidconKE2020/core/Preferences.kt
+++ b/core/src/main/java/com/android254/droidconKE2020/core/Preferences.kt
@@ -1,4 +1,10 @@
 package com.android254.droidconKE2020.core
 
+import android.content.SharedPreferences
+
 interface Preferences {
+    val sharedPref: SharedPreferences
+
+//    fun getUserName(defaultValue: String): String?
+//    fun setUserName(username: String)
 }

--- a/core/src/main/java/com/android254/droidconKE2020/core/PreferencesImpl.kt
+++ b/core/src/main/java/com/android254/droidconKE2020/core/PreferencesImpl.kt
@@ -1,0 +1,4 @@
+package com.android254.droidconKE2020.core
+
+class PreferencesImpl {
+}

--- a/core/src/main/java/com/android254/droidconKE2020/core/PreferencesImpl.kt
+++ b/core/src/main/java/com/android254/droidconKE2020/core/PreferencesImpl.kt
@@ -1,4 +1,28 @@
 package com.android254.droidconKE2020.core
 
-class PreferencesImpl {
+import android.content.Context
+import android.content.SharedPreferences
+import com.android254.droidconKE2020.core.di.Constants.SHARED_PREF_FILE_NAME
+
+class PreferencesImpl(context: Context): Preferences {
+
+    override val sharedPref: SharedPreferences = context
+        .getSharedPreferences(SHARED_PREF_FILE_NAME, Context.MODE_PRIVATE)
+
+    private fun editSharedPref(action: (s: SharedPreferences.Editor) -> Unit) {
+        with (sharedPref.edit()) {
+            action(this)
+            apply()
+        }
+    }
+
+//    override fun getUserName(defaultValue: String): String? {
+//        return sharedPref.getString("userName", defaultValue)
+//    }
+//
+//    override fun setUserName(username: String) {
+//        editSharedPref {
+//            it.putString("userName", username)
+//        }
+//    }
 }

--- a/core/src/main/java/com/android254/droidconKE2020/core/di/Constants.kt
+++ b/core/src/main/java/com/android254/droidconKE2020/core/di/Constants.kt
@@ -1,0 +1,5 @@
+package com.android254.droidconKE2020.core.di
+
+object Constants {
+    const val SHARED_PREF_FILE_NAME = "com.android254.droidconKE2020"
+}


### PR DESCRIPTION
## What is the Purpose?
Add Shared preferences in the core module

## What was the approach?
As stated by @michaelbukachi on issue #56, was to create a `PreferencesImpl` class that implements the `Preferences` interface

## Are there any concerns to addressed further before or after merging this PR?
Added a private method `editSharedPref` to avoid calling the `apply` method for every edit of the state. I think it will prevent unnecessary code duplication of `apply` method

## Mentions?
@wangerekaharun @chepsi @michaelbukachi

## Issue(s) affected?
#56 